### PR TITLE
test-env

### DIFF
--- a/app/auth/jwt.py
+++ b/app/auth/jwt.py
@@ -11,12 +11,20 @@ load_dotenv()
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES=30
 
-def create_access_token(subject: dict, expires_delta: timedelta = timedelta(minutes=5)):
-    to_encode = subject.copy()
-    to_encode.update({"exp": datetime.utcnow() + expires_delta})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-    return encoded_jwt
+def create_access_token(subject: str, expires_delta: timedelta | None = None):
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+    to_encode = {
+        "sub": subject,
+        "exp": expire,
+    }
+
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 
 async def get_current_user(request: Request):

--- a/app/auth/recaptcha.py
+++ b/app/auth/recaptcha.py
@@ -4,6 +4,13 @@ from fastapi import HTTPException
 from starlette import status
 
 def guard_captcha(token: str, expected_action: str, min_score: float = 0.5):
+    env = os.getenv("ENV", "development")
+
+    if env == "development":
+        return {
+            "score": 1.0,
+            "action": expected_action,
+        }
     secret = os.getenv("RECAPTCHA_SECRET")
 
     if not secret:

--- a/app/paraphrase/ml_model.py
+++ b/app/paraphrase/ml_model.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, List
 import threading
 import torch
 
-MODEL_NAME = "ramsrigouthamg/t5_paraphraser"
+MODEL_NAME = "tuner007/pegasus_paraphrase"
 
 _tokenizer: Optional[PreTrainedTokenizer] = None
 _model: Optional[PreTrainedModel] = None

--- a/app/tests/testUsers/test_user_dao.py
+++ b/app/tests/testUsers/test_user_dao.py
@@ -24,7 +24,7 @@ async def test_create_user(user_dao, mock_conn):
         username="developer",
         email="developer@example.com",
         hashed_password="hashed",
-        phone="0783434834",
+        phone_number="0783434834",
         role="user",
     )
 

--- a/app/users/dao.py
+++ b/app/users/dao.py
@@ -11,7 +11,7 @@ class UserDAO:
     async def get_by_email(self, email: str) -> Optional[UserDB]:
         row = await self.conn.fetchrow(
             """
-            SELECT id, username, email, phone_number, role
+            SELECT id, username, email, password, phone_number, role
             FROM users
             WHERE email = $1
             """,
@@ -42,7 +42,7 @@ class UserDAO:
         )
         return UserDB(**dict(row)) if row else None
 
-    async def create_user(self, user_id: str, username: str, email: str, hashed_password: str, phone: str, role: str = "user") -> str:
+    async def create_user(self, user_id: str, username: str, email: str, hashed_password: str, phone_number: str, role: str = "user") -> str:
         row = await self.conn.fetchrow(
             """
             INSERT INTO users (id, username, email, password, phone_number, role)
@@ -53,7 +53,7 @@ class UserDAO:
             username,
             email,
             hashed_password,
-            phone,
+            phone_number,
             role,
         )
         return row["id"]

--- a/app/users/route.py
+++ b/app/users/route.py
@@ -20,7 +20,7 @@ async def register_user(request: Request, payload: UserRegisterRequest, db_pool:
             email=payload.email,
             username=payload.username,
             password=payload.password,
-            phone=payload.phone_number,
+            phone_number=payload.phone_number,
         )
 
 @router.post("/login", response_model=TokenResponse)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.0
+argon2-cffi==25.1.0
+argon2-cffi-bindings==25.1.0
 asyncpg==0.30.0
 bcrypt==4.0.1
 certifi==2025.11.12


### PR DESCRIPTION
### Previous Implementation Overview

The original password-handling approach used:

- bcrypt via `passlib`
- A **manual SHA-256 pre-hash** step before bcrypt to bypass bcrypt’s 72-byte input limit

Argon allows the system to accept long passwords without pre-processing. This is an advantage.

- Passwords are **never pre-hashed**
- Passwords are hashed directly using **Argon2**
- Length-based validation is preferred over rigid complexity rules
- All hashing and verification use `passlib`’s managed context